### PR TITLE
Add label override

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,3 +39,13 @@ ExternalUrl::make('Google Link', function () {
     return 'https://www.google.com/search?q=' . $this->name;
 })->linkText($this->name),
 ```
+
+The label below the link normally shows the URL, but it can be overridden:
+
+```php
+use Pdewit\ExternalUrl\ExternalUrl;
+
+ExternalUrl::make('Google Link', function () {
+    return 'https://www.google.com/search?q=' . $this->name;
+})->labelText('View search results on Google'),
+```

--- a/resources/js/components/DetailField.vue
+++ b/resources/js/components/DetailField.vue
@@ -7,7 +7,7 @@
                         <svg class="fill-current w-4 h-4 mr-2 text-60" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512"><path fill="currentColor" d="M576 14.4l-.174 163.2c0 7.953-6.447 14.4-14.4 14.4H528.12c-8.067 0-14.56-6.626-14.397-14.691l2.717-73.627-2.062-2.062-278.863 278.865c-4.686 4.686-12.284 4.686-16.971 0l-23.029-23.029c-4.686-4.686-4.686-12.284 0-16.971L474.379 61.621l-2.062-2.062-73.626 2.717C390.626 62.44 384 55.946 384 47.879V14.574c0-7.953 6.447-14.4 14.4-14.4L561.6 0c7.953 0 14.4 6.447 14.4 14.4zM427.515 233.74l-24 24a12.002 12.002 0 0 0-3.515 8.485V458a6 6 0 0 1-6 6H54a6 6 0 0 1-6-6V118a6 6 0 0 1 6-6h301.976c10.691 0 16.045-12.926 8.485-20.485l-24-24A12.002 12.002 0 0 0 331.976 64H48C21.49 64 0 85.49 0 112v352c0 26.51 21.49 48 48 48h352c26.51 0 48-21.49 48-48V242.225c0-10.691-12.926-16.045-20.485-8.485z"></path></svg>
                         <span>{{ linkText }}</span>
                     </div>
-                    <span class="text-sm no-underline text-60" >{{ field.value }}</span>
+                    <span class="text-sm no-underline text-60" >{{ labelText }}</span>
                 </a>
             </div>
             <p v-else>&mdash;</p>
@@ -22,6 +22,10 @@ export default {
     computed: {
         linkText() {
             return this.field.linkText ? this.field.linkText : 'External Link';
+        },
+
+        labelText() {
+            return this.field.labelText ? this.field.labelText : this.field.value;
         }
     }
 }

--- a/src/ExternalUrl.php
+++ b/src/ExternalUrl.php
@@ -23,4 +23,8 @@ class ExternalUrl extends Field
     public function linkText($linkText) {
         return $this->withMeta(["linkText" => $linkText]);
     }
+
+    public function labelText($labelText) {
+        return $this->withMeta(["labelText" => $labelText]);
+    }
 }


### PR DESCRIPTION
This adds an optional method to override the label below the link, which by default shows the URL.